### PR TITLE
Moved to ManagedAuthenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ Installation Instructions (for Docker installations):
 * Open your container app.yml
 * Register a new Twitch API application at https://dev.twitch.tv/console/apps if you haven't already.
   * For the Redirect API: http(s)://example.com/auth/twitch/callback
-* Under section ```env:``` your Twitch API credentials must be added:
-```
-  TWITCH_CLIENT_ID: CLIENT_ID
-  TWITCH_CLIENT_SECRET: CLIENT_SECRET
-```
 * Under section ```hooks:``` append the following
 ```
           - git clone https://github.com/night/discourse-auth-twitch.git
@@ -20,4 +15,9 @@ Installation Instructions (for Docker installations):
 * Rebuild the docker container
 ```
 ./launcher rebuild my_image
+```
+* Admin configuration ```twitch``` the plugon must be enabled and your Twitch API credentials must be added:
+```
+Client Id
+Client Secret
 ```

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,8 @@
+en:
+  js:
+    login:
+      twitch:
+        name: "Twitch"
+        title: "with Twitch"
+        sr_title: "Login with Twitch"
+        message: "Authenticating with Twitch"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,0 +1,5 @@
+en:
+  site_settings:
+    sign_in_with_twitch_enabled: 'Enable sign in with Twitch?'
+    twitch_client_id: '(Sign in with Twitch) The twitch Client ID from developre console https://dev.twitch.tv/console/apps'
+    twitch_client_secret: '(Sign in with Twitch) The twitch Client Secret fom the developer console'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,10 @@
+plugins:
+  sign_in_with_twitch_enabled:
+    default: false
+    client: false
+  twitch_client_id:
+    default: ''
+    client: false
+  twitch_client_secret:
+    default: ''
+    client: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -54,7 +54,7 @@ class TwitchAuthenticator < ::Auth::Authenticator
   end
 end
 
-auth_provider :title => 'with Twitch',
+auth_provider :title => 'Twitch',
     :message => 'Log in with Twitch (Make sure pop up blockers are not enabled).',
     :frame_width => 920,
     :frame_height => 800,

--- a/plugin.rb
+++ b/plugin.rb
@@ -5,13 +5,20 @@
 
 gem 'omniauth-twitch', '1.1.0'
 
-class TwitchAuthenticator < ::Auth::Authenticator
+enabled_site_setting :sign_in_with_twitch_enabled
 
-  CLIENT_ID = ENV["TWITCH_CLIENT_ID"]
-  CLIENT_SECRET = ENV["TWITCH_CLIENT_SECRET"]
+class TwitchAuthenticator < ::Auth::ManagedAuthenticator
 
   def name
     'twitch'
+  end
+
+  def can_revoke?
+    true
+  end
+
+  def can_connect_existing_user?
+    true
   end
 
   def enabled?
@@ -52,8 +59,8 @@ class TwitchAuthenticator < ::Auth::Authenticator
 
   def register_middleware(omniauth)
     omniauth.provider :twitch,
-     CLIENT_ID,
-     CLIENT_SECRET,
+     SiteSetting.twitch_client_id,
+     SiteSetting.twitch_client_secret,
      scope: 'user:read:email'
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -14,6 +14,10 @@ class TwitchAuthenticator < ::Auth::Authenticator
     'twitch'
   end
 
+  def enabled?
+    SiteSetting.sign_in_with_twitch_enabled?
+  end
+
   def after_authenticate(auth_token)
     result = Auth::Result.new
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -25,36 +25,8 @@ class TwitchAuthenticator < ::Auth::ManagedAuthenticator
     SiteSetting.sign_in_with_twitch_enabled?
   end
 
-  def after_authenticate(auth_token)
-    result = Auth::Result.new
-
-    # grab the info we need from omni auth
-    data = auth_token[:info]
-    extra = auth_token[:extra]
-    username = data["nickname"]
-    name = data["name"]
-    email = data["email"]
-    twitch_uid = auth_token["uid"]
-
-    # plugin specific data storage
-    current_info = ::PluginStore.get("twitch", "twitch_uid_#{twitch_uid}")
-
-    result.user =
-      if current_info
-        User.where(id: current_info[:user_id]).first
-      end
-
-    result.username = username
-    result.name = name
-    result.email = email
-    result.extra_data = { twitch_uid: twitch_uid }
-
-    result
-  end
-
-  def after_create_account(user, auth)
-    data = auth[:extra_data]
-    ::PluginStore.set("twitch", "twitch_uid_#{data[:twitch_uid]}", {user_id: user.id })
+  def after_authenticate(auth_token, existing_account: nil)
+    super
   end
 
   def register_middleware(omniauth)


### PR DESCRIPTION
With a ManagedAuthenticator flow it is now possible to connect existing accounts with twitch OAuth.

OAuth keys are provided by admin console.

I have never worked with Ruby or Discourse. Just needed the function for my use case. Feel free to modify or discard.